### PR TITLE
Add caret to react-native-fs package dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "buffer": "5.0.8",
     "file-type": "7.3.0",
     "js-base64": "2.3.2",
-    "react-native-fs": "2.11.15"
+    "react-native-fs": "^2.11.15"
   },
   "devDependencies": {
     "prettier-pack": "0.0.7"


### PR DESCRIPTION
This allows for all versions of `react-native-fs` between 2.11.15 < 2.x